### PR TITLE
Fix wrong dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
    ```yaml
    dependencies:
-     color:
+     term-color:
        github: crystal-term/color
    ```
 


### PR DESCRIPTION
Upon following the installation guide, this output is given:
![image](https://user-images.githubusercontent.com/41897894/146489300-f0a82928-05f4-4b16-b62f-d501d37e7941.png)

Changing from:
```yml
dependencies:
  color:
    github: crystal-term/color
```
to:
```yml
dependencies:
  term-color:
    github: crystal-term/color
```
Fixes the issue and is the aim for this pull request.